### PR TITLE
Fork github.com/nats-io/natscli into github.com/bwerthmann/natscli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nats-io/natscli
+module github.com/bwerthmann/natscli
 
 go 1.16
 


### PR DESCRIPTION
changed module path.

Signed-off-by: Ben Werthmann <ben@synadia.com>